### PR TITLE
Disable Datadog tracer for the current process.

### DIFF
--- a/Haproxy.AgentCheck/Program.cs
+++ b/Haproxy.AgentCheck/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using Haproxy.AgentCheck.Hosting;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
@@ -8,6 +9,7 @@ namespace Haproxy.AgentCheck
     {
         public static void Main(string[] args)
         {
+            Environment.SetEnvironmentVariable("DD_TRACE_ENABLED", "0", EnvironmentVariableTarget.Process);
             CreateHostBuilder(args).Build().Run();
         }
 


### PR DESCRIPTION
dd-tracer crash the process.

Faulting module name: Haproxy.AgentCheck.exe, version: 0.0.0.0, time stamp: 0x61e1d138
Exception code: 0xc0000005
Fault offset: 0x0000000000249974
Faulting process id: 0x2410
Faulting application start time: 0x01da003345a3b26c
Faulting application path: 