### PR TITLE
Close the connection after the TCP check has completed

### DIFF
--- a/Haproxy.AgentCheck/Endpoints/TcpHandler.cs
+++ b/Haproxy.AgentCheck/Endpoints/TcpHandler.cs
@@ -25,6 +25,9 @@ internal class TcpHandler(State state, MaintenanceStatus maintenanceStatus) : Co
 
             await connection.Transport.Output.WriteAsync(Encoding.ASCII.GetBytes($"{state.Weight:F0}% {up}\n").AsMemory(), connection.ConnectionClosed);
             await connection.Transport.Output.FlushAsync(connection.ConnectionClosed);
+
+            await connection.Transport.Output.CompleteAsync();
+            await connection.Transport.Input.CompleteAsync();
         }
         catch (TaskCanceledException) when (connection.ConnectionClosed.IsCancellationRequested)
         {


### PR DESCRIPTION
This avoids ghost connections timing out after 4 minutes